### PR TITLE
link to Decomposing rust-fil-proofs Git Repository doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ _Newest to oldest_
 * [Outbound Message Queue](https://docs.google.com/document/d/1Ns5_ushX9exsKr0xbc2Kt0ZHzAA0WnVvl42hyGRR5l0/edit) - March 2019
 * [Message Tracking](https://docs.google.com/document/u/2/d/1Ofoid90l9JwyW8zUy00kaHdvpLoV4gr2mcN3s4irkPY/edit?usp=drive_web&ouid=117191042581679083795) - Feb 2019
 * [Porcelain/Plumbing Refactor Plan](https://docs.google.com/document/u/2/d/1L5hbcDGhfH3AlMti4RQ3Zke6nc4-eGOmk9lD0nNoiEs/edit?usp=drive_web&ouid=117191042581679083795) - Feb 2019
+* [Decomposing rust-fil-proofs](https://docs.google.com/document/d/1Ujqger3fMjnTVjpEahwQTRii49LlmbFjJVgNbyhUfu4/edit) - May 2019
 * [meta] [Design Docs: What are they and how we use them](https://github.com/filecoin-project/designdocs/blob/master/designdocs.md) - Aug 2018
 
 ### Video Recordings


### PR DESCRIPTION
Adds link to _Decomposing rust-fil-proofs Git Repo_ doc.